### PR TITLE
Fix require libraires to laravel 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.8] - 2020-11-12
+
+### Fixed
+- Version require ramsey/uuid and phpunit/phpunit
+- Update branch aliases
+
 ## [2.0.7] - 2020-10-28
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         "illuminate/database": "~5.5|^6.0|^7.0|^8.0",
         "illuminate/support": "~5.4|^6.0|^7.0|^8.0",
         "onelogin/php-saml": "^3.0",
-        "ramsey/uuid": "^3.8"
+        "ramsey/uuid": "^3.8|^4.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.9",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^7.5|^9.0",
         "squizlabs/php_codesniffer": "^2.3"
     },
     "autoload": {
@@ -43,7 +43,7 @@
             ]
         },
         "branch-aliases": {
-            "dev-master": "2.0.3-dev"
+            "dev-master": "2.0.8-dev"
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Laravel 8 required phpunit ^9.0 (https://laravel.com/docs/8.x/upgrade#updating-dependencies)

Not explicit in doc, but, necessary upgrade version ramsey/uuid


Problem 1
    - Conclusion: don't install 24slides/laravel-saml2 2.0.3
    - Conclusion: don't install 24slides/laravel-saml2 2.0.2
    - Conclusion: don't install 24slides/laravel-saml2 2.0.1
    - Conclusion: don't install 24slides/laravel-saml2 2.0.0
    - Conclusion: don't install 24slides/laravel-saml2 2.0.7
    - Conclusion: don't install 24slides/laravel-saml2 2.0.6
    - Conclusion: don't install 24slides/laravel-saml2 2.0.5
    - Conclusion: don't install 24slides/laravel-saml2 2.0.4
    - Conclusion: don't install 24slides/laravel-saml2 2.0.3
    - Conclusion: don't install 24slides/laravel-saml2 2.0.2
    - Conclusion: don't install 24slides/laravel-saml2 2.0.1
    - Conclusion: remove laravel/framework v8.8.0
    - Installation request for ramsey/uuid (locked at 4.1.1) -> satisfiable by ramsey/uuid[4.1.1].
    - Installation request for 24slides/laravel-saml2 ^2.0 -> satisfiable by 24slides/laravel-saml2[2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7].
    - Conclusion: don't install laravel/framework v8.8.0
