### PR TITLE
Add SignedIn event accessors, to match docs

### DIFF
--- a/src/Events/SignedIn.php
+++ b/src/Events/SignedIn.php
@@ -55,8 +55,6 @@ class SignedIn
      */
     public function getSaml2User(): Saml2User
     {
-        $this->user = $user;
-        $this->auth = $auth;
         return $this->user;
     }
 }

--- a/src/Events/SignedIn.php
+++ b/src/Events/SignedIn.php
@@ -37,4 +37,26 @@ class SignedIn
         $this->user = $user;
         $this->auth = $auth;
     }
+
+    /**
+     * Get the authentication handler for a SAML sign in attempt
+     *
+     * @return Auth The authentication handler for the SignedIn event
+     */
+    public function getAuth(): Auth
+    {
+        return $this->auth;
+    }
+
+    /**
+     * Get the user represented in the SAML sign in attempt
+     *
+     * @return Saml2User The user for the SignedIn event
+     */
+    public function getSaml2User(): Saml2User
+    {
+        $this->user = $user;
+        $this->auth = $auth;
+        return $this->user;
+    }
 }


### PR DESCRIPTION
The [library readme](https://github.com/24Slides/laravel-saml2/blob/master/README.md) gives code examples of handling authentication events,
including `$event->getAuth()` and `$event->getSame2User()`.

Before this commit, that example code will fail because those accessors don't exist.
This commit adds those accessors to match the readme code example.