### PR TITLE
Improve sls handling of errors to match acs action

### DIFF
--- a/src/Http/Controllers/Saml2Controller.php
+++ b/src/Http/Controllers/Saml2Controller.php
@@ -86,10 +86,16 @@ class Saml2Controller extends Controller
      */
     public function sls(Auth $auth)
     {
-        $error = $auth->sls(config('saml2.retrieveParametersFromServer'));
+        $errors = $auth->sls(config('saml2.retrieveParametersFromServer'));
 
-        if (!empty($error)) {
-            throw new \Exception("Could not log out");
+        if (!empty($errors)) {
+            logger()->error('saml2.error_detail', ['error' => $auth->getLastErrorReason()]);
+            session()->flash('saml2.error_detail', [$auth->getLastErrorReason()]);
+
+            logger()->error('saml2.error', $errors);
+            session()->flash('saml2.error', $errors);
+
+            return redirect(config('saml2.errorRoute'));
         }
 
         return redirect(config('saml2.logoutRoute')); //may be set a configurable default


### PR DESCRIPTION
I was noticing that an exception which I couldn't catch was being thrown and noticed that actually there was another action that handled it differently and this I thought might be better to allow the application to handle it more gracefully to not interrupt the user experience.