### PR TITLE
Added saml session tracking for global logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Event::listen(\Slides\Saml2\Events\SignedIn::class, function (\Slides\Saml2\Even
     
     $user = // find user by ID or attribute
     
+    \Slides\Saml2\Session::store($samlUser->getTenant(), $samlUser);
+    
     // Login a user.
     Auth::login($user);
 });
@@ -165,8 +167,8 @@ There are two ways the user can logout:
 - By logging out in your app. In this case you SHOULD notify the IdP first so it'll close the global session.
 - By logging out of the global SSO Session. In this case the IdP will notify you on `/saml2/{uuid}/slo` endpoint (already provided).
 
-For the first case, call `Saml2Auth::logout();` or redirect the user to the route `saml.logout` which does just that. 
-Do not close the session immediately as you need to receive a response confirmation from the IdP (redirection). 
+For the first case, call `Session::logout();` or redirect the user to the route `saml.logout` which does just that. 
+Do not close the Laravel session immediately as you need to receive a response confirmation from the IdP (redirection). 
 That response will be handled by the library at `/saml2/sls` and will fire an event for you to complete the operation.
 
 For the second case you will only receive the event. Both cases receive the same event. 

--- a/src/Session.php
+++ b/src/Session.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Slides\Saml2;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Cookie;
+use Slides\Saml2\Models\Tenant;
+use Slides\Saml2\Facades\Auth;
+use Slides\Saml2\Repositories\TenantRepository;
+use Slides\Saml2\OneLoginBuilder;
+use OneLogin\Saml2\Error as OneLoginError;
+
+/**
+ * Class Session
+ *
+ * @package Slides\Saml2
+ */
+class SamlSession
+{
+    /**
+     * @var TenantRepository
+     */
+    protected $tenants;
+
+    /**
+     * @var OneLoginBuilder
+     */
+    protected $builder;
+
+    public function __construct(TenantRepository $tenants, OneLoginBuilder $builder)
+    {
+        $this->tenants = $tenants;
+        $this->builder = $builder;
+    }
+
+    public function exists(): bool
+    {
+        return Cookie::has('saml_tenant_id');
+    }
+
+    public function store(Tenant $tenant, Saml2User $samlUser): void
+    {
+        Cookie::queue(cookie()->make('saml_tenant_id', $tenant->id, config('session.lifetime')));
+        Cookie::queue(cookie()->make('saml_session_id', $samlUser->getSessionIndex(), config('session.lifetime')));
+        Cookie::queue(cookie()->make('saml_name_id', $samlUser->getNameId(), config('session.lifetime')));
+    }
+
+    public function clear(): void
+    {
+        Cookie::queue(cookie()->forget('saml_tenant_id'));
+        Cookie::queue(cookie()->forget('saml_session_id'));
+        Cookie::queue(cookie()->forget('saml_name_id'));
+    }
+
+    /**
+     * Generates the redirect url to initiate a global session
+     * sign out for a user with the IdP.
+     */
+    public function logout(): ?RedirectResponse
+    {
+        if (!$this->exists()) {
+            return null;
+        }
+
+        $tenant = $this->resolveTenant();
+        if (empty($tenant)) {
+            return null;
+        }
+
+        $this->builder
+            ->withTenant($tenant)
+            ->bootstrap();
+
+        try {
+            $sloUrl = Auth::logout(
+                config('saml2.logoutRoute'),
+                Cookie::get('saml_name_id'),
+                Cookie::get('saml_session_id'),
+                null,
+                true
+            );
+        } catch (OneLoginError $e) {
+            report($e);
+            return null;
+        }
+
+        return redirect($sloUrl)->withHeaders([
+            'Pragma' => 'no-cache',
+            'Cache-Control' => 'no-cache, must-revalidate',
+        ]);
+    }
+
+    /**
+     * Resolve a tenant from the session.
+     */
+    protected function resolveTenant(): ?Tenant
+    {
+        $id = Cookie::get('saml_tenant_id');
+        if (empty($id)) {
+            return null;
+        }
+
+        return $this->tenants->findById($id);
+    }
+}


### PR DESCRIPTION
This helps fix #34 - curious what you might think of this idea. This is modeled after the Onelogin Wordpress plugin which  also does this.