### PR TITLE
Laravel Octane support

### DIFF
--- a/src/Http/Controllers/Saml2Controller.php
+++ b/src/Http/Controllers/Saml2Controller.php
@@ -115,7 +115,7 @@ class Saml2Controller extends Controller
     {
         $redirectUrl = $auth->getTenant()->relay_state_url ?: config('saml2.loginRoute');
 
-        $auth->login(
+        $redirectUrl = $auth->login(
             $request->query('returnTo', $redirectUrl),
             [],
             false,
@@ -138,10 +138,8 @@ class Saml2Controller extends Controller
      */
     public function logout(Request $request, Auth $auth)
     {
-        $redirectUrl = $request->query('returnTo');
-        
-        $auth->logout(
-            $redirectUrl,
+        $redirectUrl = $auth->logout(
+            $request->query('returnTo'),
             $request->query('nameId'),
             $request->query('sessionIndex'),
             null,

--- a/src/Http/Controllers/Saml2Controller.php
+++ b/src/Http/Controllers/Saml2Controller.php
@@ -115,7 +115,15 @@ class Saml2Controller extends Controller
     {
         $redirectUrl = $auth->getTenant()->relay_state_url ?: config('saml2.loginRoute');
 
-        $auth->login($request->query('returnTo', $redirectUrl));
+        $auth->login(
+            $request->query('returnTo', $redirectUrl),
+            [],
+            false,
+            false,
+            true
+        );
+
+        return redirect($redirectUrl);
     }
 
     /**
@@ -130,10 +138,16 @@ class Saml2Controller extends Controller
      */
     public function logout(Request $request, Auth $auth)
     {
+        $redirectUrl = $request->query('returnTo');
+        
         $auth->logout(
-            $request->query('returnTo'),
+            $redirectUrl,
             $request->query('nameId'),
-            $request->query('sessionIndex')
+            $request->query('sessionIndex'),
+            null,
+            true
         );
+
+        return redirect($redirectUrl);
     }
 }

--- a/src/Http/Controllers/Saml2Controller.php
+++ b/src/Http/Controllers/Saml2Controller.php
@@ -43,8 +43,9 @@ class Saml2Controller extends Controller
      * @throws OneLoginError
      * @throws \OneLogin\Saml2\ValidationError
      */
-    public function acs(Auth $auth)
+    public function acs(Auth $auth, $idpName, Request $request)
     {
+        $this->setRequest($request);
         $errors = $auth->acs();
 
         if (!empty($errors)) {
@@ -62,6 +63,8 @@ class Saml2Controller extends Controller
         event(new SignedIn($user, $auth));
 
         $redirectUrl = $user->getIntendedUrl();
+
+        $this->unsetRequest();
 
         if ($redirectUrl) {
             return redirect($redirectUrl);
@@ -84,9 +87,13 @@ class Saml2Controller extends Controller
      * @throws OneLoginError
      * @throws \Exception
      */
-    public function sls(Auth $auth)
+    public function sls(Auth $auth, $idpName, Request $request)
     {
+        $this->setRequest($request);
+
         $errors = $auth->sls(config('saml2.retrieveParametersFromServer'));
+
+        $this->unsetRequest();
 
         if (!empty($errors)) {
             logger()->error('saml2.error_detail', ['error' => $auth->getLastErrorReason()]);
@@ -111,8 +118,10 @@ class Saml2Controller extends Controller
      *
      * @throws OneLoginError
      */
-    public function login(Request $request, Auth $auth)
+    public function login(Request $request, Auth $auth, $idpName)
     {
+        $this->setRequest($request);
+
         $redirectUrl = $auth->getTenant()->relay_state_url ?: config('saml2.loginRoute');
 
         $redirectUrl = $auth->login(
@@ -122,6 +131,8 @@ class Saml2Controller extends Controller
             false,
             true
         );
+
+        $this->unsetRequest();
 
         return redirect($redirectUrl);
     }
@@ -138,6 +149,8 @@ class Saml2Controller extends Controller
      */
     public function logout(Request $request, Auth $auth)
     {
+        $this->setRequest($request);
+
         $redirectUrl = $auth->logout(
             $request->query('returnTo'),
             $request->query('nameId'),
@@ -146,6 +159,55 @@ class Saml2Controller extends Controller
             true
         );
 
+        $this->unsetRequest();
+
         return redirect($redirectUrl);
+    }
+
+    /**
+     * Add needed superglobals for php-saml that swoole does not provide
+     *
+     * @param Request $request
+     *
+     * @return void
+     */
+    private function setRequest(Request $request)
+    {
+        $_POST['SAMLResponse'] = array_key_exists('SAMLResponse', $request->post()) ? $request->post()['SAMLResponse'] : null;
+        $_GET['SAMLResponse'] = array_key_exists('SAMLResponse', $request->query()) ? $request->query()['SAMLResponse'] : null;
+        $_GET['SAMLRequest'] = array_key_exists('SAMLRequest', $request->query()) ? $request->query()['SAMLRequest'] : null;
+        $_GET['RelayState'] = array_key_exists('RelayState', $request->query()) ? $request->query()['RelayState'] : null;
+        $_GET['Signature'] = array_key_exists('Signature', $request->query()) ? $request->query()['Signature'] : null;
+        $_REQUEST['RelayState'] = array_key_exists('RelayState', $request->all()) ? $request->all()['RelayState'] : null;
+
+        if (!empty($request->server->get('HTTP_X_FORWARDED_PROTO'))) {
+            $_SERVER['HTTP_X_FORWARDED_PROTO'] = $request->server->get('HTTP_X_FORWARDED_PROTO');
+        }
+        if (!empty($request->server->get('HTTP_X_FORWARDED_HOST'))) {
+            $_SERVER['HTTP_X_FORWARDED_HOST'] = $request->server->get('HTTP_X_FORWARDED_HOST');
+        } else {
+            $_SERVER['HTTP_HOST'] = parse_url(config('app.url'), PHP_URL_HOST);
+        }
+    }
+
+    /**
+     * Remove superglobals that were needed for php-saml that swoole does not provide
+     *
+     *
+     * @return void
+     */
+    private function unsetRequest()
+    {
+        unset(
+            $_POST['SAMLResponse'],
+            $_GET['SAMLResponse'],
+            $_GET['SAMLRequest'],
+            $_GET['RelayState'],
+            $_GET['Signature'],
+            $_REQUEST['RelayState'],
+            $_SERVER['HTTP_X_FORWARDED_PROTO'],
+            $_SERVER['HTTP_X_FORWARDED_HOST'],
+            $_SERVER['HTTP_HOST'],
+        );
     }
 }


### PR DESCRIPTION
This PR sets the $stay parameter to true to prevent Utils.php redirecting with exit();

setRequest based on https://gist.github.com/haught/09f48e172ec347787b542eb03e23bd5f

This will enable the package to work with Laravel Octane (swoole)