### PR TITLE
[2.2.1] Add tenant uuid to salm2.error_detail, to provide more context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2023-09-28
+
+### Added
+- Add uuid of tenant to `salm2.error_detail`; makes logs more informative (PR #74, @vopolonc)
+
 ## [2.2.0] - 2023-02-20
 
 ### Added

--- a/src/Http/Controllers/Saml2Controller.php
+++ b/src/Http/Controllers/Saml2Controller.php
@@ -48,8 +48,11 @@ class Saml2Controller extends Controller
         $errors = $auth->acs();
 
         if (!empty($errors)) {
-            logger()->error('saml2.error_detail', ['error' => $auth->getLastErrorReason()]);
-            session()->flash('saml2.error_detail', [$auth->getLastErrorReason()]);
+            $error = $auth->getLastErrorReason();
+            $uuid = $auth->getTenant()->uuid;
+
+            logger()->error('saml2.error_detail', compact('uuid', 'error'));
+            session()->flash('saml2.error_detail', [$error]);
 
             logger()->error('saml2.error', $errors);
             session()->flash('saml2.error', $errors);
@@ -89,8 +92,11 @@ class Saml2Controller extends Controller
         $errors = $auth->sls(config('saml2.retrieveParametersFromServer'));
 
         if (!empty($errors)) {
-            logger()->error('saml2.error_detail', ['error' => $auth->getLastErrorReason()]);
-            session()->flash('saml2.error_detail', [$auth->getLastErrorReason()]);
+            $error = $auth->getLastErrorReason();
+            $uuid = $auth->getTenant()->uuid;
+
+            logger()->error('saml2.error_detail', compact('uuid', 'error'));
+            session()->flash('saml2.error_detail', [$error]);
 
             logger()->error('saml2.error', $errors);
             session()->flash('saml2.error', $errors);


### PR DESCRIPTION
Add `uuid` of tenant to `salm2.error_detail` (makes logs more informative)