### PR TITLE
Make it easy to subclass Saml2Controller

### DIFF
--- a/config/saml2.php
+++ b/config/saml2.php
@@ -138,6 +138,16 @@ return [
     'proxyVars' => false,
 
     /*
+    | (Optional) Which class implements the route functions.
+    | If left blank, defaults to this lib's controller (Slides\Saml2\Http\Controllers\Saml2Controller).
+    | If you need to extend Saml2Controller (e.g. to override the `login()` function to pass
+    | a `$returnTo` argument), this value allows you to pass your own controller, and have
+    | it used in the routes definition.
+    |
+    */
+    'saml2_controller' => '',
+
+    /*
     |--------------------------------------------------------------------------
     | Service Provider configuration.
     |--------------------------------------------------------------------------

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -6,28 +6,30 @@ Route::group([
     'prefix' => config('saml2.routesPrefix'),
     'middleware' => array_merge(['saml2.resolveTenant'], config('saml2.routesMiddleware')),
 ], function () {
+    $saml2_controller = config('saml2.saml2_controller', 'Slides\Saml2\Http\Controllers\Saml2Controller');
+
     Route::get('/{uuid}/logout', array(
         'as' => 'saml.logout',
-        'uses' => 'Slides\Saml2\Http\Controllers\Saml2Controller@logout',
+        'uses' => $saml2_controller.'@logout',
     ));
 
     Route::get('/{uuid}/login', array(
         'as' => 'saml.login',
-        'uses' => 'Slides\Saml2\Http\Controllers\Saml2Controller@login',
+        'uses' => $saml2_controller.'@login',
     ));
 
     Route::get('/{uuid}/metadata', array(
         'as' => 'saml.metadata',
-        'uses' => 'Slides\Saml2\Http\Controllers\Saml2Controller@metadata',
+        'uses' => $saml2_controller.'@metadata',
     ));
 
     Route::post('/{uuid}/acs', array(
         'as' => 'saml.acs',
-        'uses' => 'Slides\Saml2\Http\Controllers\Saml2Controller@acs',
+        'uses' => $saml2_controller.'@acs',
     ));
 
     Route::get('/{uuid}/sls', array(
         'as' => 'saml.sls',
-        'uses' => 'Slides\Saml2\Http\Controllers\Saml2Controller@sls',
+        'uses' => $saml2_controller.'@sls',
     ));
 });


### PR DESCRIPTION
There is a feature in the aacotroneo/laravel-saml2 library which allows users to extend the controller without having to redefine all the routes by defining a `saml2_controller` config value, which you can see [here](https://github.com/aacotroneo/laravel-saml2/commit/34fe227c2683dd8ed2a2b439731bb5a1755841b7).

It's very simple to implement, and I was able to duplicate the functionality with minimal tweaks to rectify stylistic differences between the two repos. My intent here is to make it easier for users of the aacotroneo lib to switch over to this one (and by users I mean me, specifically, but I'm sure other people could also use this feature).