### PR TITLE
Make --metadata take a JSON object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "24slides/laravel-saml2",
+    "name": "pixelcat/laravel-saml2",
     "type": "library",
     "description": "SAML2 Service Provider integration to your Laravel 5.4+ application, based on OneLogin toolkit",
     "keywords": ["laravel", "saml", "saml2", "onelogin", "sso"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pixelcat/laravel-saml2",
+    "name": "24slides/laravel-saml2",
     "type": "library",
     "description": "SAML2 Service Provider integration to your Laravel 5.4+ application, based on OneLogin toolkit",
     "keywords": ["laravel", "saml", "saml2", "onelogin", "sso"],

--- a/src/Commands/CreateTenant.php
+++ b/src/Commands/CreateTenant.php
@@ -28,7 +28,7 @@ class CreateTenant extends \Illuminate\Console\Command
                             { --relayStateUrl= : Redirection URL after successful login }
                             { --nameIdFormat= : Name ID Format ("persistent" by default) }
                             { --x509cert= : x509 certificate (base64) }
-                            { --metadata= : A custom metadata }';
+                            { --metadata= : A custom metadata (JSON) }';
 
     /**
      * The console command description.
@@ -82,7 +82,7 @@ class CreateTenant extends \Illuminate\Console\Command
         }
 
         $key = $this->option('key');
-        $metadata = ConsoleHelper::stringToArray($this->option('metadata'));
+        $metadata = $metadata ? \json_encode($this->option('metadata')) : '';
 
         if($key && ($tenant = $this->tenants->findByKey($key))) {
             $this->renderTenants($tenant, 'Already found tenant(s) using this key');

--- a/src/Commands/CreateTenant.php
+++ b/src/Commands/CreateTenant.php
@@ -82,7 +82,7 @@ class CreateTenant extends \Illuminate\Console\Command
         }
 
         $key = $this->option('key');
-        $metadata = $metadata ? \json_encode($this->option('metadata')) : '';
+        $metadata = $metadata ? \json_encode($this->option('metadata')) : '[]';
 
         if($key && ($tenant = $this->tenants->findByKey($key))) {
             $this->renderTenants($tenant, 'Already found tenant(s) using this key');

--- a/src/Commands/RendersTenants.php
+++ b/src/Commands/RendersTenants.php
@@ -66,7 +66,7 @@ trait RendersTenants
             'Relay State URL' => $tenant->relay_state_url,
             'Name ID format' => $tenant->name_id_format,
             'x509 cert' => Str::limit($tenant->idp_x509_cert, 50),
-            'Metadata' => $this->renderArray($tenant->metadata ?: []),
+            'Metadata' => json_decode($tenant->metadata ?: []),
             'Created' => $tenant->created_at->toDateTimeString(),
             'Updated' => $tenant->updated_at->toDateTimeString(),
             'Deleted' => $tenant->deleted_at ? $tenant->deleted_at->toDateTimeString() : null
@@ -91,23 +91,5 @@ trait RendersTenants
             'Logout URL: <comment>' . route('saml.logout', ['uuid' => $tenant->uuid]) . '</comment>',
             'Relay State: <comment>' . ($tenant->relay_state_url ?: config('saml2.loginRoute')) . ' (optional)</comment>'
         ]);
-    }
-
-    /**
-     * Print an array to a string.
-     *
-     * @param array $array
-     *
-     * @return string
-     */
-    protected function renderArray(array $array)
-    {
-        $lines = [];
-
-        foreach ($array as $key => $value) {
-            $lines[] = "$key: $value";
-        }
-
-        return implode(PHP_EOL, $lines);
     }
 }

--- a/src/Commands/RendersTenants.php
+++ b/src/Commands/RendersTenants.php
@@ -66,7 +66,7 @@ trait RendersTenants
             'Relay State URL' => $tenant->relay_state_url,
             'Name ID format' => $tenant->name_id_format,
             'x509 cert' => Str::limit($tenant->idp_x509_cert, 50),
-            'Metadata' => json_decode($tenant->metadata ?: []),
+            'Metadata' => print_r($tenant->metadata ?: [],1),
             'Created' => $tenant->created_at->toDateTimeString(),
             'Updated' => $tenant->updated_at->toDateTimeString(),
             'Deleted' => $tenant->deleted_at ? $tenant->deleted_at->toDateTimeString() : null

--- a/src/Commands/UpdateTenant.php
+++ b/src/Commands/UpdateTenant.php
@@ -67,7 +67,7 @@ class UpdateTenant extends \Illuminate\Console\Command
 
         if ($this->option('metadata')) {
             $metadata = $this->option('metadata') ? json_decode($this->option('metadata', '[]')) : null;
-            if ($json_error = json_last_error_msg()) {
+            if (($json_error = json_last_error_msg()) !== 'No error') {
                 $this->error($json_error);
                 return;
             }

--- a/src/Commands/UpdateTenant.php
+++ b/src/Commands/UpdateTenant.php
@@ -27,7 +27,7 @@ class UpdateTenant extends \Illuminate\Console\Command
                             { --relayStateUrl= : Redirection URL after successful login }
                             { --nameIdFormat= : Name ID Format ("persistent" by default) }
                             { --x509cert= : x509 certificate (base64) }
-                            { --metadata= : A custom metadata }';
+                            { --metadata= : A custom metadata (JSON format) }';
 
     /**
      * The console command description.
@@ -65,6 +65,14 @@ class UpdateTenant extends \Illuminate\Console\Command
             return;
         }
 
+        if ($this->option('metadata')) {
+            $metadata = $this->option('metadata') ? json_decode($this->option('metadata', '[]')) : null;
+            if ($json_error = json_last_error_msg()) {
+                $this->error($json_error);
+                return;
+            }
+        }
+
         $tenant->update(array_filter([
             'key' => $this->option('key'),
             'idp_entity_id' => $this->option('entityId'),
@@ -73,7 +81,7 @@ class UpdateTenant extends \Illuminate\Console\Command
             'idp_x509_cert' => $this->option('x509cert'),
             'relay_state_url' => $this->option('relayStateUrl'),
             'name_id_format' => $this->resolveNameIdFormat(),
-            'metadata' => ConsoleHelper::stringToArray($this->option('metadata'))
+            'metadata' => $metadata,
         ]));
 
         if(!$tenant->save()) {


### PR DESCRIPTION
Background:

The metadata parsing as it exists today won't honor http:// schema names, which we need in order to support multiple IdP types, and specifically Microsoft Entra ID which uses schemas instead of simple strings.

As part of our implementation we store those schema names as mappings to field names in metadata, such as the following:

```
| Metadata        | Array                                                                                             
|                 | (                                                                                                             
|                 |     [field_email] => http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
|                 |     [field_lastName] => http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname
|                 |     [field_uniqueId] => http://schemas.microsoft.com/identity/claims/objectidentifier 
|                 |     [field_firstName] => http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname                     
|                 | )
```

Solution: Instead of mapping metadata to an array based on `:` as a separator, this PR allows users to specify metadata as a serialized JSON string during creation or update.