### PR TITLE
#105: Destroy local session during SLO flow

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -4,6 +4,7 @@ namespace Slides\Saml2;
 
 use OneLogin\Saml2\Auth as OneLoginAuth;
 use OneLogin\Saml2\Error as OneLoginError;
+use OneLogin\Saml2\Utils as OneLoginUtils;
 use Slides\Saml2\Events\SignedOut;
 use Slides\Saml2\Models\Tenant;
 
@@ -167,6 +168,7 @@ class Auth
     public function sls($retrieveParametersFromServer = false)
     {
         $this->base->processSLO(false, null, $retrieveParametersFromServer, function () {
+            OneLoginUtils::deleteLocalSession();
             event(new SignedOut());
         });
 


### PR DESCRIPTION
It appears that by adding a callable with the event here https://github.com/24Slides/laravel-saml2/blob/master/src/Auth.php#L169-L171 , this package overrides upstream session destroy . See https://github.com/SAML-Toolkits/php-saml/blob/master/lib/Saml2/Auth.php#L283-L286.

Calling that explicitly to fix the single log out flow initiated by IDP reported in #105 .