### PR TITLE
php 8.4 deprecation message

### DIFF
--- a/src/Commands/RendersTenants.php
+++ b/src/Commands/RendersTenants.php
@@ -20,7 +20,7 @@ trait RendersTenants
      *
      * @return void
      */
-    protected function renderTenants($tenants, string $title = null)
+    protected function renderTenants($tenants, ?string $title = null)
     {
         /** @var \Slides\Saml2\Models\Tenant[]|\Illuminate\Database\Eloquent\Collection $tenants */
         $tenants = $tenants instanceof Tenant

--- a/src/Helpers/ConsoleHelper.php
+++ b/src/Helpers/ConsoleHelper.php
@@ -22,7 +22,7 @@ class ConsoleHelper
      *
      * @return array
      */
-    public static function stringToArray(string $string = null, string $valueDelimiter = ':', string $itemDelimiter = ',')
+    public static function stringToArray(?string $string = null, string $valueDelimiter = ':', string $itemDelimiter = ',')
     {
         if(is_null($string)) {
             return [];

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -37,7 +37,7 @@ if (!function_exists('saml_route'))
      *
      * @return string
      */
-    function saml_route(string $name, string $uuid = null, $parameters = [])
+    function saml_route(string $name, ?string $uuid = null, $parameters = [])
     {
         $target = \Illuminate\Support\Facades\URL::route($name, $parameters, true);
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -12,7 +12,7 @@ if (!function_exists('saml_url'))
      *
      * @return string
      */
-    function saml_url(string $path, string $uuid = null, $parameters = [], bool $secure = null)
+    function saml_url(string $path, ?string $uuid = null, $parameters = [], ?bool $secure = null)
     {
         $target = \Illuminate\Support\Facades\URL::to($path, $parameters, $secure);
 


### PR DESCRIPTION
Fixes: 

PHP Deprecated:  saml_url(): Implicitly marking parameter $secure as nullable is deprecated, the explicit nullable type must be used instead in /vendor/24slides/laravel-saml2/src/helpers.php on line 15

Deprecated: saml_url(): Implicitly marking parameter $secure as nullable is deprecated, the explicit nullable type must be used instead in /vendor/24slides/laravel-saml2/src/helpers.php on line 15

More info: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated