### PR TITLE
Improve RelayState handling

### DIFF
--- a/src/Http/Controllers/Saml2Controller.php
+++ b/src/Http/Controllers/Saml2Controller.php
@@ -66,7 +66,7 @@ class Saml2Controller extends Controller
 
         $redirectUrl = $user->getIntendedUrl();
 
-        if ($redirectUrl) {
+        if (!empty($redirectUrl) && $redirectUrl !== 'undefined') {
             return redirect($redirectUrl);
         }
 


### PR DESCRIPTION
In some cases, `RelayState` may not be defined in the IdP.

If not provided, the value becomes `undefined`, putting the user in an undesired state (my-app.com/undefined).

This adds better handling of `RelayState` and provides a fallback to the configured `loginRoute`.